### PR TITLE
Add isinstance check on __eq__ implementation

### DIFF
--- a/aioytmdesktopapi/player.py
+++ b/aioytmdesktopapi/player.py
@@ -23,6 +23,8 @@ class Player:
         return generate_attribute_string(self, attributes)
 
     def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Player):
+            return NotImplemented
         return self._raw == other._raw
 
     @property

--- a/aioytmdesktopapi/track.py
+++ b/aioytmdesktopapi/track.py
@@ -24,6 +24,8 @@ class Track:
         return generate_attribute_string(self, attributes)
 
     def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Track):
+            return NotImplemented
         return self._raw == other._raw
 
     @property


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type checking in comparison methods to prevent errors when objects of different types are compared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->